### PR TITLE
Feature/expand pan area

### DIFF
--- a/dist/ChartContainer.js
+++ b/dist/ChartContainer.js
@@ -453,7 +453,12 @@ var ChartContainer = (0, _react.forwardRef)(function (_ref, ref) {
     ref: container,
     className: "orgchart-container " + containerClass,
     onWheel: zoom ? zoomHandler : undefined,
-    onMouseUp: pan && panning ? panEndHandler : undefined
+    onMouseDown: pan ? panStartHandler : undefined,
+    onMouseUp: pan && panning ? panEndHandler : undefined,
+    onMouseMove: pan && panning ? panHandler : undefined,
+    style: {
+      cursor: cursor
+    }
   }, _react.default.createElement("div", {
     ref: chart,
     className: "orgchart " + chartClass,
@@ -461,9 +466,7 @@ var ChartContainer = (0, _react.forwardRef)(function (_ref, ref) {
       transform: transform,
       cursor: cursor
     },
-    onClick: clickChartHandler,
-    onMouseDown: pan ? panStartHandler : undefined,
-    onMouseMove: pan && panning ? panHandler : undefined
+    onClick: clickChartHandler
   }, _react.default.createElement("ul", null, _react.default.createElement(_ChartNode.default, {
     className: "oc-node " + nodeClass,
     datasource: attachRel(ds, "00"),

--- a/src/components/ChartContainer.js
+++ b/src/components/ChartContainer.js
@@ -364,15 +364,15 @@ const ChartContainer = forwardRef(
         ref={container}
         className={"orgchart-container " + containerClass}
         onWheel={zoom ? zoomHandler : undefined}
+        onMouseDown={pan ? panStartHandler : undefined}
         onMouseUp={pan && panning ? panEndHandler : undefined}
+        onMouseMove={pan && panning ? panHandler : undefined}
       >
         <div
           ref={chart}
           className={"orgchart " + chartClass}
           style={{ transform: transform, cursor: cursor }}
           onClick={clickChartHandler}
-          onMouseDown={pan ? panStartHandler : undefined}
-          onMouseMove={pan && panning ? panHandler : undefined}
         >
           <ul>
             <ChartNode

--- a/src/components/ChartContainer.js
+++ b/src/components/ChartContainer.js
@@ -367,6 +367,7 @@ const ChartContainer = forwardRef(
         onMouseDown={pan ? panStartHandler : undefined}
         onMouseUp={pan && panning ? panEndHandler : undefined}
         onMouseMove={pan && panning ? panHandler : undefined}
+        style={{cursor: cursor}}
       >
         <div
           ref={chart}


### PR DESCRIPTION
## Description of the change

> Expand the panning area to be the whole container instead of only the chart.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> https://www.notion.so/Expand-the-draggable-background-to-be-much-larger-f5d8c2ba84ab478a8585b6c86909bb80

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
